### PR TITLE
docs: set default failure policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
 # Install the latest version of Gatekeeper with the external data feature enabled.
 helm install gatekeeper/gatekeeper \
     --set enableExternalData=true \
+    --set validatingWebhookFailurePolicy=Fail \
     --name-template=gatekeeper \
     --namespace security \
     --create-namespace


### PR DESCRIPTION
## Summary
Sets the validating webhook failure policy for Gatekeeper to fail closed (defaults to ignore) for example installation.

### Tests
n/a

### Issue
n/a
