### PR TITLE
chore: remove GitHub app usage now that attest is public

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,6 @@ jobs:
         with:
           username: dockerpublicbot
           password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
-        with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.DOCKER_READ_APP_PRIVATE_KEY }}
-          repositories: "attest,attest-provider"
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -52,5 +45,3 @@ jobs:
           platforms: linux/amd64,linux/arm64 # todo figure out additional platforms for release
           attests: type=sbom,generator=docker/scout-sbom-indexer:1
           provenance: mode=max
-          secrets: |
-            GITHUB_TOKEN=${{ steps.app-token.outputs.token }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -24,14 +24,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
-        with:
-          app-id: ${{ vars.DOCKER_READ_APP_ID }}
-          private-key: ${{ secrets.DOCKER_READ_APP_PRIVATE_KEY }}
-          repositories: "attest,attest-provider"
-
       - name: Set up Go 1.22
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
@@ -39,12 +31,6 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Download dependencies
-        run: |
-          export GOPRIVATE="github.com/docker/attest"
-          git config --global "url.https://x-access-token:${{ steps.app-token.outputs.token }}@github.com.insteadof" "https://github.com"
-          go mod download
 
       # source: https://github.com/golangci/golangci-lint-action
       - name: golangci-lint
@@ -71,14 +57,6 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
-        with:
-          app-id: ${{ vars.DOCKER_READ_APP_ID }}
-          private-key: ${{ secrets.DOCKER_READ_APP_PRIVATE_KEY }}
-          repositories: "attest,attest-provider"
 
       - name: Bootstrap e2e
         env:
@@ -110,7 +88,6 @@ jobs:
       - name: Build and install attest-provider
         run: |
           ./scripts/generate-tls-cert.sh
-          export GITHUB_TOKEN=${{ steps.app-token.outputs.token }}
           make docker-buildx kind-load-image
           helm install attest-provider charts/attest-provider \
             --set provider.tls.caBundle="$(cat certs/ca.crt | base64 | tr -d '\n\r')" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,24 +20,12 @@ ENV CGO_ENABLED=0
 
 WORKDIR /app
 
-# --- This block can be removed when github.com/docker/attest is public
-ENV GOPRIVATE="github.com/docker/attest"
-RUN --mount=type=secret,id=GITHUB_TOKEN <<EOT
-  set -e
-  GITHUB_TOKEN=${GITHUB_TOKEN:-$(cat /run/secrets/GITHUB_TOKEN)}
-  if [ -n "$GITHUB_TOKEN" ]; then
-    echo "Setting GitHub access token"
-    git config --global "url.https://x-access-token:${GITHUB_TOKEN}@github.com.insteadof" "https://github.com"
-  fi
-EOT
-# ---
-
 ARG VERSION="dev"
 
 RUN --mount=type=bind,source=.,target=/app \
-    --mount=type=cache,target=$GOPATH/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    go build -ldflags "-X main.version=$VERSION" -o /bin/attest main.go
+  --mount=type=cache,target=$GOPATH/pkg/mod \
+  --mount=type=cache,target=/root/.cache/go-build \
+  go build -ldflags "-X main.version=$VERSION" -o /bin/attest main.go
 
 FROM ${BASEIMAGE} AS production
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ docker-buildx-builder:
 
 .PHONY: docker-buildx
 docker-buildx: docker-buildx-builder
-	docker buildx build --platform linux/amd64 --load -t ${IMG} . --secret=id=GITHUB_TOKEN
+	docker buildx build --platform linux/amd64 --load -t ${IMG} .
 
 .PHONY: kind-load-image
 kind-load-image:


### PR DESCRIPTION
Remove use of Docker Read App - we also no longer have access to the token now that this repo is public, and we don't need it anyway as the attest repo is also public.